### PR TITLE
Added all_of when selecting from external grouping_variables vector i…

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: PHEindicatormethods
 Type: Package
-Version: 2.0.1.9004
+Version: 2.0.1.9005
 Title: Common Public Health Statistics and their Confidence Intervals 
 Description: Functions to calculate commonly used public health statistics and 
     their confidence intervals using methods approved for use in the production  

--- a/R/SII_function.R
+++ b/R/SII_function.R
@@ -736,7 +736,7 @@ phe_sii <- function(data, quantile, population,  # compulsory fields
               }
               )
             ) |>
-            select(grouping_variables, "CI_calcs")
+            select(all_of(grouping_variables), "CI_calcs")
 
           # Add CIs to model
           # join on dataset with SII/ RII confidence limits
@@ -744,7 +744,7 @@ phe_sii <- function(data, quantile, population,  # compulsory fields
           # Unnest confidence limits in a data frame for joining
 
           CI_rep1 <- popsSII_model_CIs %>%
-            select(grouping_variables, "CI_calcs") %>%
+            select(all_of(grouping_variables), "CI_calcs") %>%
             tidyr::unnest("CI_calcs") |>
             slice_head(n = 1)
 


### PR DESCRIPTION
…n phe_sii function to get rid of tidyselect warning.